### PR TITLE
build: stand up CI, governance lint, and flywheel releases

### DIFF
--- a/.flywheel.yml
+++ b/.flywheel.yml
@@ -1,0 +1,7 @@
+flywheel:
+  streams:
+    - name: main-line
+      branches:
+        - name: main
+          release: production
+          auto_merge: [fix, chore, docs]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  # ruff and pyright are pinned to py312 in pyproject.toml, so one leg
+  # carries the full lint signal; only pytest is version-sensitive.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.12"
+      - run: uv sync
+      - run: uv run ruff format --check .
+      - run: uv run ruff check .
+      - run: uv run pyright
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # hatch-vcs derives the version from tag history
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync
+      - run: uv run pytest
+      # Device tests self-skip without hardware; the mock path exercises
+      # the CLI wiring end to end.
+      - run: uv run bmd-signal-gen --mock-device pat2 --duration 0.2

--- a/.github/workflows/flywheel-pr.yml
+++ b/.github/workflows/flywheel-pr.yml
@@ -1,0 +1,25 @@
+name: Flywheel — PR
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+concurrency:
+  group: flywheel-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  conduct:
+    # Skip drafts; ignore `edited` events from bots (only a human editing the
+    # title/body should retrigger the conventional-commit rewrite). Skips
+    # cleanly when the flywheel App credentials are absent.
+    if: |
+      vars.FLYWHEEL_GH_APP_ID != '' &&
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'edited' || github.event.sender.type == 'User')
+    runs-on: ubuntu-latest
+    steps:
+      # SHA-pinned (no floating tags for third-party actions); the trailing
+      # # vX.Y.Z comment is for human review. Mirrors display-patterns.
+      - uses: point-source/flywheel@59758d1940ebe054ce9fdd4b7a7dc79a0cf235e0 # v2.1.0
+        with:
+          event: pull_request
+          app-id: ${{ vars.FLYWHEEL_GH_APP_ID }}
+          app-private-key: ${{ secrets.FLYWHEEL_GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/flywheel-push.yml
+++ b/.github/workflows/flywheel-push.yml
@@ -1,0 +1,22 @@
+name: Flywheel — Push
+on:
+  push:
+    branches: ["**"]
+concurrency:
+  group: flywheel-push-${{ github.ref_name }}
+  cancel-in-progress: false
+jobs:
+  release:
+    # Skips cleanly when the flywheel GitHub App credentials are absent
+    # (vars.FLYWHEEL_GH_APP_ID, secrets.FLYWHEEL_GH_APP_PRIVATE_KEY are
+    # org-level on OpenLEDEval).
+    if: vars.FLYWHEEL_GH_APP_ID != ''
+    runs-on: ubuntu-latest
+    steps:
+      # SHA-pinned (no floating tags for third-party actions); the trailing
+      # # vX.Y.Z comment is for human review. Mirrors display-patterns.
+      - uses: point-source/flywheel@59758d1940ebe054ce9fdd4b7a7dc79a0cf235e0 # v2.1.0
+        with:
+          event: push
+          app-id: ${{ vars.FLYWHEEL_GH_APP_ID }}
+          app-private-key: ${{ secrets.FLYWHEEL_GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -1,0 +1,11 @@
+name: Governance Lint
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    uses: repentsinner/symphonize/.github/workflows/governance-lint.yml@notation--v0
+    with:
+      readme-type: "application"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,1 @@
+{"MD013": false, "MD024": false, "MD036": false}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ installed from git. No SDK download or C++ toolchain is required.
    ```
 
 2. **Verify installation**:
+
    ```bash
    uv run bmd-signal-gen --help
    ```
@@ -175,7 +176,7 @@ The primary recommended video output is HDMI. SDI support is currently less well
 
 ### Project Structure
 
-```
+```text
 bmd-signal-gen/
 ├── bmd_sg/                           # Main Python package
 │   ├── api/                          # REST API implementation

--- a/SPEC.md
+++ b/SPEC.md
@@ -50,7 +50,7 @@ established device surface:
 Why this surface: it is the existing `BMDDeckLink` API. Twelve call sites
 (CLI, API server, examples) and the mock already code to it, so the swap is
 confined to one adapter and callers do not change. pydecklink's own SPEC
-names this integration path (§spec:test-pattern-generation): a narrow
+names this integration path (`§spec:test-pattern-generation` there): a narrow
 protocol in signal-gen that either backend satisfies.
 
 Why device-level HDR metadata: pydecklink attaches HDR metadata per frame

--- a/bmd_sg/decklink/bmd_decklink.py
+++ b/bmd_sg/decklink/bmd_decklink.py
@@ -278,9 +278,32 @@ class EOTFType(str, Enum):
     def __new__(cls, value: str, *args: Any):
         self = str.__new__(cls, value)
         self._value_ = value
-        for a in args:
-            self._add_value_alias_(a)  # type: ignore Added in python 3.13
+        del args  # consumed by __init__ as int_value
         return self
+
+    @classmethod
+    def _missing_(cls, value: object) -> "EOTFType | None":
+        """
+        Resolve ``EOTFType(2)``-style lookups by SDK integer code.
+
+        Replaces the ``_add_value_alias_`` API, which exists only on
+        Python 3.13+, so integer lookups work on every supported version.
+
+        Parameters
+        ----------
+        value : object
+            Candidate lookup value; only integers resolve.
+
+        Returns
+        -------
+        EOTFType or None
+            The member whose ``int_value`` matches, or None.
+        """
+        if isinstance(value, int):
+            for member in cls:
+                if member.int_value == value:
+                    return member
+        return None
 
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "bmd-signal-generator"
-version = "0.2.0"
+# Version derives from git tags (hatch-vcs); flywheel cuts the tags.
+dynamic = ["version"]
 description = "Cross-platform BMD signal generator for Blackmagic Design DeckLink devices with HDR metadata support"
 authors = [
     { name = "Ritchie Argue", email = "4462072+repentsinner@users.noreply.github.com" },
@@ -70,8 +71,12 @@ bmd-signal-gen = "bmd_sg.cli.main:app"
 display-patterns = { git = "https://github.com/OpenLEDEval/display-patterns", tag = "v0.1.0" }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["bmd_sg"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,3 +165,7 @@ reportUnboundVariable = false
 reportUnnecessaryCast = true
 reportUnsupportedDunderAll = false
 reportUnusedExpression = false
+[tool.pytest.ini_options]
+# examples/ are runnable scripts, not tests — one opens a real device at
+# import time. Scope collection so bare `pytest` matches `invoke test`.
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ reportUnboundVariable = false
 reportUnnecessaryCast = true
 reportUnsupportedDunderAll = false
 reportUnusedExpression = false
+
 [tool.pytest.ini_options]
 # examples/ are runnable scripts, not tests — one opens a real device at
 # import time. Scope collection so bare `pytest` matches `invoke test`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,9 @@ select = [
     "SIM", # flake8-simplify
     "TCH", # flake8-type-checking
     "RUF", # Ruff-specific rules
+    # Blanket `# type: ignore` can silence version-compatibility errors
+    # (it hid the 3.13-only enum-alias call from pyright's 3.12 check).
+    "PGH003", # blanket-type-ignore
 ]
 ignore = [
     "E501", # Line too long (handled by formatter)

--- a/tests/test_decklink_output.py
+++ b/tests/test_decklink_output.py
@@ -46,8 +46,16 @@ class TestBackend:
         assert hasattr(bmd_decklink_module, "pydecklink")
 
     def test_get_decklink_devices_returns_names(self) -> None:
-        """Device enumeration returns a list of device name strings."""
-        devices = get_decklink_devices()
+        """Device enumeration returns a list of device name strings.
+
+        Enumeration needs the Desktop Video driver but no connected
+        device; on a driverless host (CI runners) it raises, so skip
+        there rather than fail.
+        """
+        try:
+            devices = get_decklink_devices()
+        except RuntimeError as error:
+            pytest.skip(f"DeckLink driver unavailable: {error}")
         assert isinstance(devices, list)
         assert all(isinstance(name, str) for name in devices)
 

--- a/tests/test_decklink_output.py
+++ b/tests/test_decklink_output.py
@@ -137,3 +137,10 @@ class TestHardwareAdapter:
             frame = np.full((1080, 1920, 3), max_code // 2, dtype=np.uint16)
             device.display_frame(frame)
             device.stop_playback()
+
+
+def test_eotf_integer_lookup_resolves_on_all_supported_pythons():
+    """``EOTFType(2)`` resolves by SDK code via ``_missing_`` (works on 3.12)."""
+    assert bmd_decklink_module.EOTFType(2) is bmd_decklink_module.EOTFType.PQ
+    assert bmd_decklink_module.EOTFType(0) is bmd_decklink_module.EOTFType.RESERVED
+    assert bmd_decklink_module.EOTFType.parse("hlg") is bmd_decklink_module.EOTFType.HLG

--- a/uv.lock
+++ b/uv.lock
@@ -54,7 +54,6 @@ wheels = [
 
 [[package]]
 name = "bmd-signal-generator"
-version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "display-patterns", extra = ["charts", "io"] },


### PR DESCRIPTION
## Summary

stand up CI, governance lint, and flywheel releases

## Changes

### build

- derive the package version from git tags via hatch-vcs (971fd2e)
- release via flywheel, mirroring display-patterns (b5eed30)

### ci

- lint, type-check, and test on every push and PR (e6258b6)
- lint governance docs via the shared symphonize workflow (46754b1)

### fix

- resolve EOTF integer lookups without the 3.13-only enum alias API (d3ed877)

### docs

- give fences blank-line padding and a language (98bf048)

### test

- skip enumeration on driverless hosts (6c631b5)

### chore

- ban blanket type-ignore comments (0323c81)

---

**Increment type:** none
**Target branch:** main
**Status:** 👀 `flywheel:needs-review` — `build` is not in auto_merge list for `main`
**Quality checks:** see required status checks for live state.