### PR TITLE
build(deps): bump display-patterns to v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     # SPEC §spec:pattern-library and [tool.uv.sources] below. The chart
     # stack (colour-science, Pillow, PyYAML, scipy, tifffile) arrives
     # through its extras — do not re-pin those here.
-    "display-patterns[charts,io]>=0.1.0",
+    "display-patterns[charts,io]>=0.2.0",
     "numpy>=2.3.1",
     "fastapi>=0.111.0",
     "pydantic>=2.12",
@@ -68,7 +68,7 @@ Changelog = "https://github.com/OpenLEDEval/bmd-signal-gen/blob/main/CHANGELOG.m
 bmd-signal-gen = "bmd_sg.cli.main:app"
 
 [tool.uv.sources]
-display-patterns = { git = "https://github.com/OpenLEDEval/display-patterns", tag = "v0.1.0" }
+display-patterns = { git = "https://github.com/OpenLEDEval/display-patterns", tag = "v0.2.0" }
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "display-patterns", extras = ["charts", "io"], git = "https://github.com/OpenLEDEval/display-patterns?tag=v0.1.0" },
+    { name = "display-patterns", extras = ["charts", "io"], git = "https://github.com/OpenLEDEval/display-patterns?tag=v0.2.0" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "numpy", specifier = ">=2.3.1" },
     { name = "pillow", specifier = ">=12.1.1" },
@@ -198,8 +198,8 @@ wheels = [
 
 [[package]]
 name = "display-patterns"
-version = "0.1.0"
-source = { git = "https://github.com/OpenLEDEval/display-patterns?tag=v0.1.0#3e99ffd53474ee13e57dae6893a94fe45933dbfd" }
+version = "0.2.0"
+source = { git = "https://github.com/OpenLEDEval/display-patterns?tag=v0.2.0#d2fcd5f0de5cfadaacdbd34ac6580bc2fe91783d" }
 dependencies = [
     { name = "numpy" },
 ]


### PR DESCRIPTION
## Summary

bump display-patterns to v0.2.0

## Changes

### build

- bump display-patterns to v0.2.0 (a281229)

---

**Increment type:** none
**Target branch:** main
**Status:** 👀 `flywheel:needs-review` — `build` is not in auto_merge list for `main`
**Quality checks:** see required status checks for live state.