### PR TITLE
docs: point at OpenDisplayEval after the org rename

### DIFF
--- a/.github/workflows/flywheel-push.yml
+++ b/.github/workflows/flywheel-push.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     # Skips cleanly when the flywheel GitHub App credentials are absent
     # (vars.FLYWHEEL_GH_APP_ID, secrets.FLYWHEEL_GH_APP_PRIVATE_KEY are
-    # org-level on OpenLEDEval).
+    # org-level on OpenDisplayEval).
     if: vars.FLYWHEEL_GH_APP_ID != ''
     runs-on: ubuntu-latest
     steps:

--- a/.memories/PROJECT_SUMMARY.md
+++ b/.memories/PROJECT_SUMMARY.md
@@ -18,7 +18,7 @@ Cross-platform BMD signal generator for Blackmagic Design DeckLink devices with 
 **`commands/`**: Pattern commands (`checkerboard_commands.py`, `solid.py`, `device_details.py`)
 
 ### `/bmd_sg/image_generators/` and `/bmd_sg/charts/`
-Deprecation shims only — `PatternGenerator`, `ROI`, chart production, and TIFF I/O live in the [display-patterns](https://github.com/OpenLEDEval/display-patterns) package (SPEC §spec:pattern-library); import `display_patterns.*` in new code
+Deprecation shims only — `PatternGenerator`, `ROI`, chart production, and TIFF I/O live in the [display-patterns](https://github.com/OpenDisplayEval/display-patterns) package (SPEC §spec:pattern-library); import `display_patterns.*` in new code
 
 ### `/bmd_sg/utilities/`
 **`__init__.py`**: `suppress_cpp_output()` context manager for native library output redirection

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, OpenLEDEval
+Copyright (c) 2025, OpenDisplayEval
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > authors primarily develop on macOS but have made their best effort to make the
 > software cross-platform. If you encounter issues or have questions, please
 > start a
-> [GitHub Discussion](https://github.com/OpenLEDEval/bmd-signal-gen/discussions).
+> [GitHub Discussion](https://github.com/OpenDisplayEval/bmd-signal-gen/discussions).
 
 A cross-platform BMD signal generator for Blackmagic Design DeckLink devices
 that outputs test patterns with comprehensive HDR metadata support. This project
@@ -54,7 +54,7 @@ both capable of full 12-bit RGB output at 1080p30.
 DeckLink access comes from
 [pydecklink](https://github.com/Fuse-Technical-Group/pydecklink), installed
 from PyPI. Pattern and chart math comes from
-[display-patterns](https://github.com/OpenLEDEval/display-patterns),
+[display-patterns](https://github.com/OpenDisplayEval/display-patterns),
 installed from git. No SDK download or C++ toolchain is required.
 
 ### Installation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ New work enters at the tail; completed work is deleted.
 ## Pattern library extraction §road:pattern-library
 
 The pattern/chart modules moved to
-[display-patterns](https://github.com/OpenLEDEval/display-patterns)
+[display-patterns](https://github.com/OpenDisplayEval/display-patterns)
 v0.1.0 — extraction spine complete; PyPI publishing is deferred and
 tracked in display-patterns' own roadmap (`§road:first-release` there).
 bmd-signal-gen consumes the package from git and keeps the legacy

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,13 +84,13 @@ to every frame it builds. Callers keep the simpler device-level model.
 
 `bmd_sg/image_generators/` and `bmd_sg/charts/` imported nothing from the
 device layer: a generic pattern/chart library carried inside a DeckLink
-tool. Other OpenLEDEval tools could not consume the math without DeckLink
+tool. Other OpenDisplayEval tools could not consume the math without DeckLink
 baggage.
 
 ### Split
 
 The modules and their tests moved verbatim to
-[display-patterns](https://github.com/OpenLEDEval/display-patterns)
+[display-patterns](https://github.com/OpenDisplayEval/display-patterns)
 (import package `display_patterns`): `bmd_sg/image_generators/` →
 `display_patterns.image_generators`, `bmd_sg/charts/` →
 `display_patterns.charts`. The package is a numpy-only core taking a

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -82,7 +82,7 @@ Pattern Generation (display-patterns)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pattern and chart generation moved to the
-`display-patterns <https://github.com/OpenLEDEval/display-patterns>`_
+`display-patterns <https://github.com/OpenDisplayEval/display-patterns>`_
 package (see SPEC §spec:pattern-library). ``bmd_sg.image_generators``
 and ``bmd_sg.charts`` remain as deprecation shims for one release
 cycle.

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -8,7 +8,7 @@ Development Setup
 
 1. **Clone the Repository**::
 
-    git clone https://github.com/OpenLEDEval/bmd-signal-gen.git
+    git clone https://github.com/OpenDisplayEval/bmd-signal-gen.git
     cd bmd-signal-gen
 
 2. **Install Dependencies**::
@@ -241,7 +241,7 @@ Getting Help
 
 **Resources:**
   * Project documentation at https://bmd-signal-gen.readthedocs.io/
-  * Issue tracker at https://github.com/OpenLEDEval/bmd-signal-gen/issues
+  * Issue tracker at https://github.com/OpenDisplayEval/bmd-signal-gen/issues
   * DeckLink SDK documentation from Blackmagic Design
 
 **Before Asking:**

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -54,7 +54,7 @@ Install from PyPI (when available)::
 
 Install from source::
 
-    git clone https://github.com/OpenLEDEval/bmd-signal-gen.git
+    git clone https://github.com/OpenDisplayEval/bmd-signal-gen.git
     cd bmd-signal-gen
     pip install uv
     uv sync
@@ -65,7 +65,7 @@ Development Installation
 
 For development work::
 
-    git clone https://github.com/OpenLEDEval/bmd-signal-gen.git
+    git clone https://github.com/OpenDisplayEval/bmd-signal-gen.git
     cd bmd-signal-gen
     pip install uv
     uv sync --group dev --group docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,17 +58,17 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/OpenLEDEval/bmd-signal-gen"
-Repository = "https://github.com/OpenLEDEval/bmd-signal-gen.git"
+Homepage = "https://github.com/OpenDisplayEval/bmd-signal-gen"
+Repository = "https://github.com/OpenDisplayEval/bmd-signal-gen.git"
 Documentation = "https://bmd-signal-gen.readthedocs.io/"
-Issues = "https://github.com/OpenLEDEval/bmd-signal-gen/issues"
-Changelog = "https://github.com/OpenLEDEval/bmd-signal-gen/blob/main/CHANGELOG.md"
+Issues = "https://github.com/OpenDisplayEval/bmd-signal-gen/issues"
+Changelog = "https://github.com/OpenDisplayEval/bmd-signal-gen/blob/main/CHANGELOG.md"
 
 [project.scripts]
 bmd-signal-gen = "bmd_sg.cli.main:app"
 
 [tool.uv.sources]
-display-patterns = { git = "https://github.com/OpenLEDEval/display-patterns", tag = "v0.2.0" }
+display-patterns = { git = "https://github.com/OpenDisplayEval/display-patterns", tag = "v0.2.0" }
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "display-patterns", extras = ["charts", "io"], git = "https://github.com/OpenLEDEval/display-patterns?tag=v0.2.0" },
+    { name = "display-patterns", extras = ["charts", "io"], git = "https://github.com/OpenDisplayEval/display-patterns?tag=v0.2.0" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "numpy", specifier = ">=2.3.1" },
     { name = "pillow", specifier = ">=12.1.1" },
@@ -199,7 +199,7 @@ wheels = [
 [[package]]
 name = "display-patterns"
 version = "0.2.0"
-source = { git = "https://github.com/OpenLEDEval/display-patterns?tag=v0.2.0#d2fcd5f0de5cfadaacdbd34ac6580bc2fe91783d" }
+source = { git = "https://github.com/OpenDisplayEval/display-patterns?tag=v0.2.0#d2fcd5f0de5cfadaacdbd34ac6580bc2fe91783d" }
 dependencies = [
     { name = "numpy" },
 ]


### PR DESCRIPTION
## Summary

point at OpenDisplayEval after the org rename

## Changes

### docs

- point at OpenDisplayEval after the org rename (4fbd0e4)

---

**Increment type:** none
**Target branch:** main
**Status:** ✅ `flywheel:auto-merge` — `docs` is in auto_merge list for `main`
**Quality checks:** see required status checks for live state.